### PR TITLE
Correct platform name

### DIFF
--- a/library.json
+++ b/library.json
@@ -23,7 +23,7 @@
     ]
   },
   "frameworks": "*",
-  "platforms": ["rp2040", "mbed_rp2040", "mbed_nano"],
+  "platforms": ["raspberrypi"],
   "examples": "examples/*/*/*.ino",
   "license": "MIT"
 }


### PR DESCRIPTION
`platforms` must refer to an existing platform name. https://github.com/platformio/platform-raspberrypi exists (name `raspberrypi`), but not any of the other referenced names.